### PR TITLE
[feature/Auth_REF-46] Auth Test Code and REST Docs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,6 +75,7 @@ dependencies {
 	testImplementation("io.kotest:kotest-assertions-core:4.4.3")
 	implementation("io.kotest:kotest-extensions-spring:4.4.3")
 
+	implementation(group="it.ozimov", name="embedded-redis", version = "0.7.2")
 }
 
 

--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -1,0 +1,39 @@
+= 2ntrip API Docs
+Powered By Dongwhwan Lee, https://github.com/hwanld
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 1
+:sectlinks:
+
+[[Auth_with_ExpiredAccessToken]]
+== Auth_with_ExpiredAccessToken
+
+operation::Auth_with_ExpiredAccessToken[snippets='http-request,request-headers,http-response,response-body,response-fields']
+
+[[Auth_with_InvalidAccessToken]]
+== Auth_with_InvalidAccessToken
+
+operation::Auth_with_InvalidAccessToken[snippets='http-request,request-headers,http-response,response-body,response-fields']
+
+[[Auth_reIssue]]
+== Auth_reIssue
+
+operation::Auth_reIssue[snippets='http-request,path-parameters,http-response,response-body,response-fields']
+
+[[Auth_reIssue_beforeAccessTokenExpired]]
+== Auth_reIssue_beforeAccessTokenExpired
+
+operation::Auth_reIssue_beforeAccessTokenExpired[snippets='http-request,path-parameters,http-response,response-body,response-fields']
+
+[[Auth_reIssue_withExpiredRefreshToken]]
+== Auth_reIssue_withExpiredRefreshToken
+
+operation::Auth_reIssue_withExpiredRefreshToken[snippets='http-request,path-parameters,http-response,response-body,response-fields']
+
+[[Auth_reIssue_withInvalidRefreshToken]]
+== Auth_reIssue_withInvalidRefreshToken
+
+operation::Auth_reIssue_withInvalidRefreshToken[snippets='http-request,path-parameters,http-response,response-body,response-fields']
+

--- a/src/main/kotlin/com/entrip/auth/jwt/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/entrip/auth/jwt/JwtTokenProvider.kt
@@ -26,6 +26,9 @@ class JwtTokenProvider(
 ) {
     private var logger: Logger = LoggerFactory.getLogger(JwtTokenProvider::class.java)
 
+    var accessTokenValidTime : Long = 10 * 60 * 1000L
+    var refreshTokenValidTime : Long = 3600 * 60 * 1000L
+
 
     // 객체 초기화. secretKey를 Base64로 인코딩
     @PostConstruct
@@ -51,17 +54,15 @@ class JwtTokenProvider(
 
     fun createAccessToken(userPk: String): String {
         //token Valid Time : 1 min
-        val tokenValidTime = 10 * 60 * 1000L
-        val accessToken = createToken(userPk, tokenValidTime)
-        redisService.setValues(userPk + "A", accessToken, Duration.ofMillis(tokenValidTime))
+        val accessToken = createToken(userPk, accessTokenValidTime)
+        redisService.setValues(userPk + "A", accessToken, Duration.ofMillis(accessTokenValidTime))
         return accessToken
     }
 
     fun createRefreshToken(userPk: String): String {
         //token Valid Time : 1 day
-        val tokenValidTime = 3600 * 60 * 1000L
-        val refreshToken = createToken(userPk, tokenValidTime)
-        redisService.setValues(userPk + "R", refreshToken, Duration.ofMillis(tokenValidTime))
+        val refreshToken = createToken(userPk, refreshTokenValidTime)
+        redisService.setValues(userPk + "R", refreshToken, Duration.ofMillis(refreshTokenValidTime))
         return refreshToken
     }
 

--- a/src/main/kotlin/com/entrip/config/EmbeddedRedisConfig.kt
+++ b/src/main/kotlin/com/entrip/config/EmbeddedRedisConfig.kt
@@ -29,7 +29,7 @@ class EmbeddedRedisConfig(
 
     @PreDestroy
     fun stopRedis() {
-        if (redisServer == null) {
+        if (redisServer != null) {
             redisServer.stop()
         }
     }

--- a/src/main/kotlin/com/entrip/config/EmbeddedRedisConfig.kt
+++ b/src/main/kotlin/com/entrip/config/EmbeddedRedisConfig.kt
@@ -1,0 +1,37 @@
+package com.entrip.config
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import redis.embedded.RedisServer
+import javax.annotation.PostConstruct
+import javax.annotation.PreDestroy
+
+@Profile("test")
+@Configuration
+class EmbeddedRedisConfig(
+    @Value("#{redis['spring.redis.port']}")
+    private val redisPort: Int
+
+) {
+
+    private final val logger = LoggerFactory.getLogger(EmbeddedRedisConfig::class.java)
+
+    private lateinit var redisServer : RedisServer
+
+    @PostConstruct
+    fun redisServer() {
+        redisServer = RedisServer(redisPort)
+        logger.info("Current working redis server's port is : $redisPort")
+        redisServer.start()
+    }
+
+    @PreDestroy
+    fun stopRedis() {
+        if (redisServer == null) {
+            redisServer.stop()
+        }
+    }
+
+}

--- a/src/main/kotlin/com/entrip/config/RedisConfig.kt
+++ b/src/main/kotlin/com/entrip/config/RedisConfig.kt
@@ -1,9 +1,9 @@
 package com.entrip.config
 
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.PropertySource
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
@@ -16,6 +16,8 @@ import org.springframework.data.redis.serializer.StringRedisSerializer
 //@PropertySource("/home/ec2-user/app/step3/properties/application-redis.properties")
 //@PropertySource("classpath:/application-redis.properties")
 class RedisConfig {
+    private final val logger = LoggerFactory.getLogger(RedisConfig::class.java)
+
     @Value("#{redis['spring.redis.host']}")
     private val host: String? = null
 
@@ -24,6 +26,7 @@ class RedisConfig {
 
     @Bean
     fun redisConnectionFactory(): RedisConnectionFactory {
+        logger.info("Current working port is : $port")
         return LettuceConnectionFactory(host!!, port!!)
     }
 

--- a/src/test/kotlin/com/entrip/auth/AuthIntegrationTest.kt
+++ b/src/test/kotlin/com/entrip/auth/AuthIntegrationTest.kt
@@ -1,0 +1,389 @@
+package com.entrip.auth
+
+import com.entrip.auth.jwt.JwtTokenProvider
+import com.entrip.domain.RestAPIMessages
+import com.entrip.domain.dto.Users.UsersLoginRequestDto
+import com.entrip.domain.dto.Users.UsersSaveRequestDto
+import com.entrip.repository.UsersRepository
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringExtension
+import org.junit.jupiter.api.extension.ExtendWith
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.restdocs.RestDocumentationExtension
+import org.springframework.restdocs.headers.HeaderDocumentation.headerWithName
+import org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
+import org.springframework.restdocs.operation.preprocess.Preprocessors
+import org.springframework.restdocs.payload.JsonFieldType
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
+import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
+import org.springframework.restdocs.request.RequestDocumentation.pathParameters
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.MvcResult
+import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ExtendWith(RestDocumentationExtension::class)
+@AutoConfigureRestDocs
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
+@ActiveProfiles("test")
+class AuthIntegrationTest() : BehaviorSpec() {
+
+    override fun extensions() = listOf(SpringExtension)
+    private final val logger = LoggerFactory.getLogger(AuthIntegrationTest::class.java)
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var usersRepository: UsersRepository
+
+    @Autowired
+    lateinit var jwtTokenProvider: JwtTokenProvider
+
+    final val user_id = "test@gmail.com"
+    final val nickname = "testNickname"
+    final val gender = 1
+    final val photoUrl = "testPhotoUrl.com"
+    final val password = "testPassword"
+
+    final val objectMapper = ObjectMapper().registerModule(KotlinModule())
+
+    lateinit var accessToken: String
+    lateinit var refreshToken: String
+
+    init {
+        beforeSpec {
+            usersRepository.deleteAll()
+        }
+
+        beforeEach {
+            saveTestUsers()
+            getNewTokenValue()
+        }
+
+        afterEach {
+            getNewTokenValue()
+            deleteTestUsers()
+            resetTokenValidTimeToNormalValue()
+        }
+
+        given("invalid Access Token 값으로") {
+            val expectedResponse = RestAPIMessages(
+                httpStatus = 400,
+                message = "SignatureException",
+                data = "Access Token is not valid!"
+            )
+            `when`("v1 메소드를 호출하는 경우") {
+                then("SignatureException 이 throw 된다.") {
+                    mockMvc.perform(
+                        RestDocumentationRequestBuilders.get("/api/v1/users/{user_id}", user_id)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header("AccessToken", accessToken + "invalid")
+                    )
+                        .andExpect(status().isBadRequest)
+                        .andExpect(content().json(objectMapper.writeValueAsString(expectedResponse)))
+                        .andDo(
+                            MockMvcRestDocumentation.document(
+                                "Auth_with_InvalidAccessToken",
+                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                                requestHeaders(
+                                    headerWithName("AccessToken").description("Invalid AccessToken")
+                                ),
+                                responseFields(
+                                    fieldWithPath("httpStatus").description("HTTP 상태 코드").type(JsonFieldType.NUMBER),
+                                    fieldWithPath("message").description("메시지").type(JsonFieldType.STRING),
+                                    fieldWithPath("data").description("데이터").type(JsonFieldType.STRING),
+                                )
+
+                            )
+                        )
+                }
+            }
+        }
+
+        given("AccessToken 이 만료된 상태로") {
+            val expectedResponseWithExpiredAccessToken = RestAPIMessages(
+                httpStatus = 400,
+                message = "ExpiredAccessTokenException",
+                data = "Access Token was expired! Please refresh!"
+            )
+
+            val expectedResponseWithReIssue = RestAPIMessages(
+                httpStatus = 400,
+                message = "Change Access Token",
+                data = "Access Token was expired! Please refresh!"
+            )
+
+            `when`("v1 메소드를 호출하는 경우") {
+                then("ExpiredAccessTokenException 이 throw 된다.") {
+                    // Make AccessToken valid time to 1s
+                    jwtTokenProvider.accessTokenValidTime = 1 * 1000L
+
+                    // Get New AccessToken with valid time is 1s
+                    getNewTokenValue()
+
+                    // Wait AccessToken being expired
+                    Thread.sleep(1000L)
+
+                    mockMvc.perform(
+                        RestDocumentationRequestBuilders.get("/api/v1/users/{user_id}", user_id)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header("AccessToken", accessToken)
+                    )
+                        .andExpect(status().isBadRequest)
+                        .andExpect(content().json(objectMapper.writeValueAsString(expectedResponseWithExpiredAccessToken)))
+                        .andDo(
+                            MockMvcRestDocumentation.document(
+                                "Auth_with_ExpiredAccessToken",
+                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                                requestHeaders(
+                                    headerWithName("AccessToken").description("Expired AccessToken")
+                                ),
+                                responseFields(
+                                    fieldWithPath("httpStatus").description("HTTP 상태 코드").type(JsonFieldType.NUMBER),
+                                    fieldWithPath("message").description("메시지").type(JsonFieldType.STRING),
+                                    fieldWithPath("data").description("데이터").type(JsonFieldType.STRING),
+                                )
+
+                            )
+                        )
+                }
+            }
+
+            `when`("reIssue 를 요청하면") {
+                then("새로운 AccessToken 이 발급된다.") {
+                    // Make AccessToken valid time to 1s
+                    jwtTokenProvider.accessTokenValidTime = 1 * 1000L
+
+                    // Get New AccessToken with valid time is 1s
+                    getNewTokenValue()
+
+                    // Wait AccessToken being expired
+                    Thread.sleep(1000L)
+
+                    val result = mockMvc.perform(
+                        RestDocumentationRequestBuilders.get("/api/v2/users/reIssue/{refreshToken}", refreshToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                    )
+                        .andExpect(status().isOk)
+                        .andDo(
+                            MockMvcRestDocumentation.document(
+                                "Auth_reIssue",
+                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                                pathParameters(
+                                    parameterWithName("refreshToken").description("refresh Token 값"),
+                                ),
+                                responseFields(
+                                    fieldWithPath("httpStatus").description("HTTP 상태 코드").type(JsonFieldType.NUMBER),
+                                    fieldWithPath("message").description("메시지").type(JsonFieldType.STRING),
+                                    fieldWithPath("data").description("데이터").type(JsonFieldType.STRING),
+                                )
+
+                            )
+                        )
+                        .andReturn()
+
+                    val response = result.response.contentAsString
+                    val restAPIMessages = objectMapper.readValue<RestAPIMessages>(response, RestAPIMessages::class.java)
+                    accessToken = restAPIMessages.data.toString()
+
+                    mockMvc.perform(
+                        RestDocumentationRequestBuilders.get("/api/v1/users/{user_id}", user_id)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header("AccessToken", accessToken)
+                    ).andExpect(status().isOk)
+
+                }
+            }
+        }
+
+        given("AccessToken 이 만료되지 않은 상태에서") {
+            val expectedResponseWithReIssueBeforeAccessTokenExpired = RestAPIMessages(
+                httpStatus = 400,
+                message = "ReIssueBeforeAccessTokenExpiredException",
+                data = "ReIssue before Access Token Expired !!!"
+            )
+            `when`("reIssue 를 요청하면") {
+                then("ReIssueBeforeAccessTokenExpiredException 이 throw 된다") {
+
+                    mockMvc.perform(
+                        RestDocumentationRequestBuilders.get("/api/v2/users/reIssue/{refreshToken}", refreshToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                    )
+                        .andExpect(status().isBadRequest)
+                        .andExpect(content().json(objectMapper.writeValueAsString(expectedResponseWithReIssueBeforeAccessTokenExpired)))
+                        .andDo(
+                            MockMvcRestDocumentation.document(
+                                "Auth_reIssue_beforeAccessTokenExpired",
+                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                                pathParameters(
+                                    parameterWithName("refreshToken").description("refresh Token 값"),
+                                ),
+                                responseFields(
+                                    fieldWithPath("httpStatus").description("HTTP 상태 코드").type(JsonFieldType.NUMBER),
+                                    fieldWithPath("message").description("메시지").type(JsonFieldType.STRING),
+                                    fieldWithPath("data").description("데이터").type(JsonFieldType.STRING),
+                                )
+
+                            )
+                        )
+
+                }
+            }
+        }
+
+        given("RefreshToken 이 invalid 한 상태에서") {
+            `when`("reIssue 를 요청하는 경우") {
+                 then("Exception 이 throw 된다") {
+                     mockMvc.perform(
+                         RestDocumentationRequestBuilders.get("/api/v2/users/reIssue/{refreshToken}", refreshToken+"invalid")
+                             .contentType(MediaType.APPLICATION_JSON)
+                     )
+                         .andExpect(status().isInternalServerError)
+                         .andDo(
+                             MockMvcRestDocumentation.document(
+                                 "Auth_reIssue_withInvalidRefreshToken",
+                                 Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                                 Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                                 pathParameters(
+                                     parameterWithName("refreshToken").description("refresh Token 값"),
+                                 ),
+                                 responseFields(
+                                     fieldWithPath("httpStatus").description("HTTP 상태 코드").type(JsonFieldType.NUMBER),
+                                     fieldWithPath("message").description("메시지").type(JsonFieldType.STRING),
+                                     fieldWithPath("data").description("데이터").type(JsonFieldType.STRING),
+                                 )
+
+                             )
+                         )
+                }
+            }
+        }
+
+        given("RefreshToken 이 expired 한 상태에서") {
+            val expectedResponseWithExpiredRefreshToken = RestAPIMessages(
+                httpStatus = 500,
+                message = "Exception",
+                data = "Request processing failed; nested exception is io.jsonwebtoken.SignatureException: Refresh token Signature is not valid"
+            )
+
+            `when`("reIssue 를 요청하는 경우") {
+                then("Exception 이 throw 된다") {
+
+                    // Make Token valid time to 1s
+                    jwtTokenProvider.accessTokenValidTime = 1 * 1000L
+                    jwtTokenProvider.refreshTokenValidTime = 1 * 1000L
+
+                    // Get New AccessToken with valid time is 1s
+                    getNewTokenValue()
+
+                    // Wait AccessToken being expired
+                    Thread.sleep(1000L)
+
+                    mockMvc.perform(
+                        RestDocumentationRequestBuilders.get("/api/v2/users/reIssue/{refreshToken}", refreshToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                    )
+                        .andExpect(status().isServiceUnavailable)
+                        .andDo(
+                            MockMvcRestDocumentation.document(
+                                "Auth_reIssue_withExpiredRefreshToken",
+                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                                pathParameters(
+                                    parameterWithName("refreshToken").description("refresh Token 값"),
+                                ),
+                                responseFields(
+                                    fieldWithPath("httpStatus").description("HTTP 상태 코드").type(JsonFieldType.NUMBER),
+                                    fieldWithPath("message").description("메시지").type(JsonFieldType.STRING),
+                                    fieldWithPath("data").description("데이터").type(JsonFieldType.STRING),
+                                )
+
+                            )
+                        )
+                }
+            }
+        }
+
+    }
+
+    private fun getNewTokenValue() {
+        val usersLoginRequestDto = UsersLoginRequestDto(
+            user_id, password
+        )
+        val result = mockMvc.post("/api/v2/users/login") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(usersLoginRequestDto)
+        }.andReturn()
+
+        accessToken = getContent(result, "accessToken")
+        refreshToken = getContent(result, "refreshToken")
+    }
+
+    private fun resetTokenValidTimeToNormalValue() {
+        jwtTokenProvider.accessTokenValidTime = 10 * 60 * 1000L
+        jwtTokenProvider.refreshTokenValidTime = 3600 * 60 * 1000L
+    }
+
+    private fun saveTestUsers() {
+        val usersSaveRequestDto = UsersSaveRequestDto(
+            user_id, nickname, gender, photoUrl, password
+        )
+
+        mockMvc.post("/api/v2/users") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(usersSaveRequestDto)
+        }
+    }
+
+    private fun deleteTestUsers() {
+        mockMvc.delete("/api/v1/users/{user_id}", user_id) {
+            contentType = MediaType.APPLICATION_JSON
+            header("AccessToken", accessToken)
+        }
+    }
+}
+
+fun BehaviorSpec.getContent(result: MvcResult, target: String): String {
+    val objectMapper = ObjectMapper().registerModule(KotlinModule())
+
+    // 1. MockMvcResult의 response를 String (JSON)으로 바꾼다
+    val response = result.response.contentAsString
+
+    // 2. String (JSON)을 RestAPIMessages로 변환한다
+    val restAPIMessages = objectMapper.readValue<RestAPIMessages>(response, RestAPIMessages::class.java)
+
+    // 3. RestAPIMessages의 data 필드를 String으로 다시 변환한다
+    val str = restAPIMessages.data.toString()
+
+    // 4. String으로 바꾼 data 필드를 전처리해서 target 값을 찾아낸다
+    val pairs = str.substring(1, str.length - 1).split(", ")
+    for (pair in pairs) {
+        val keyValue = pair.split("=")
+        if (keyValue[0] == target) {
+            return keyValue[1]
+        }
+    }
+
+    return ""
+}


### PR DESCRIPTION
### Auth Integration 테스트의 경우, 
1. beforeEach로 새로운 유저에 대해서 회원가입, 로그인 및 token 값을 모두 받아옴
2. afterEach로 회원가입된 사용자로 로그인해서 token을 받아온 후 항상 회원탈퇴를 진행

### Test Situation
1. accessToken의 invalid 값으로 메소드를 호출하는 경우
2. accessToken의 만료 이후 메소드 호출하는경우
3. accessToken 만료 이후 reIssue 요청하는 경우
4. accessToken 만료 이전 reIssue 요청하는 경우
5. refreshToken의 invalid 값으로 reIssue 요청하는 경우
6. refreshToken의 만료 이후 reIssue 요청하는 경우